### PR TITLE
Collect system includes too

### DIFF
--- a/cook/cpp.py
+++ b/cook/cpp.py
@@ -329,7 +329,7 @@ def object(
 
         if scan:
             depfile = core.temporary(core.random('.d'))
-            command.extend(['-MMD', '-MF', depfile])
+            command.extend(['-MD', '-MF', depfile])
         else:
             depfile = None
 


### PR DESCRIPTION
Currently, only project includes are tracked by Cook. This means that updating an external library changes the included files without leading to a rebuild. This change fixes that by collecting system includes as well by using `-MMD` instead of `-MD`.