### PR TITLE
Add default environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ install:
 script:
   - 'cd examples'
   - 'cd cpp && cook -v && cd ..'
-  - 'cd cpp_warning && cook -v && cd ..'
+  - 'cd cpp_warning'
+  - 'cook -v | grep "unused_var"'
+  - 'cook -v | grep "unused_var"'
+  - 'cd ..'
   - 'cd file && cook -v && cd ..'
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - C++ rules allow specifying `linkflags`
 - Support for MSVC 2017
 - Experimental rules for native Android apps
+- New `timeout` parameter for `core.call()`
 
 ### Changed
 - Using `cook --targets` will now list paths relative to the build directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Using `cook --targets` will now list paths relative to the build directory
 - Includes in system directories will now be tracked too
+- Disabled restriction of output paths having to be in the build directory
 
 ### Fixed
 - The task-failed handler was not properly protected against exceptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for MSVC 2017
 - Experimental rules for native Android apps
 - New `timeout` parameter for `core.call()`
+- Mechanism to prevent accidental deletes by using a wrong build directory
 
 ### Changed
 - Using `cook --targets` will now list paths relative to the build directory

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ def replace(source, destination, mapping):
     with open(source) as file:
         content = file.read()
     for key, value in mapping.items():
-        content.replace(key, value)
+        content = content.replace(key, value)
     with open(destination, 'w') as file:
         file.write(content)
 ```

--- a/cook/core/builder.py
+++ b/cook/core/builder.py
@@ -48,8 +48,8 @@ def start(jobs, request=None):
 
     for task in graph.tasks:
         # Only display warning if we will not rebuild it.
-        if record.has_primary(task) and task not in outdated:
-            warnings = record.get_warnings(task)
+        if record.has_primary(task.primary) and task not in outdated:
+            warnings = record.get_warnings(task.primary)
             if warnings is not None:
                 log.warning('Warnings by {}:\n{}'.format(task, warnings))
 

--- a/cook/core/loader.py
+++ b/cook/core/loader.py
@@ -62,7 +62,7 @@ def load(path):
 
     with open(path) as f:
         content = f.read()
-    symbols = {}
+    symbols = {'__file__': path}
     exec(compile(content, path, 'exec'), symbols)
 
     directories.pop()

--- a/cook/core/misc.py
+++ b/cook/core/misc.py
@@ -255,22 +255,16 @@ class CallError(Exception):
             cmdline, self.returned)
 
 
-_default_env = {}
-for name in ('TMP', 'TEMP', 'PATH'):
-    if name in os.environ:
-        _default_env[name] = os.environ[name]
-
-
-def call(command, cwd=None, env=None):
+def call(command, cwd=None, env=None, timeout=None):
     log.debug('CALL {}'.format(subprocess.list2cmdline(command)))
 
     if env is None:
-        env = _default_env
+        env = os.environ
 
     try:
         output = subprocess.check_output(
             command, stderr=subprocess.STDOUT, env=env, cwd=cwd,
-            stdin=subprocess.DEVNULL
+            stdin=subprocess.DEVNULL, timeout=timeout
         )
         return output.decode(errors='ignore')
     except subprocess.CalledProcessError as e:

--- a/cook/core/misc.py
+++ b/cook/core/misc.py
@@ -255,11 +255,17 @@ class CallError(Exception):
             cmdline, self.returned)
 
 
+_default_env = {}
+for name in ('TMP', 'TEMP', 'PATH'):
+    if name in os.environ:
+        _default_env[name] = os.environ[name]
+
+
 def call(command, cwd=None, env=None):
     log.debug('CALL {}'.format(subprocess.list2cmdline(command)))
 
     if env is None:
-        env = {}
+        env = _default_env
 
     try:
         output = subprocess.check_output(

--- a/cook/core/rules.py
+++ b/cook/core/rules.py
@@ -66,8 +66,8 @@ def publish(
         for output in outputs:
             if graph.has_file(output):
                 raise ValueError('output collision')
-            elif not phony and not misc.is_inside(output, system.build('.')):
-                raise ValueError('output outside of build directory')
+            # elif not phony and not misc.is_inside(output, system.build('.')):
+            #     raise ValueError('output outside of build directory')
 
     if not isinstance(result, dict):
         if result is None:

--- a/cook/core/system.py
+++ b/cook/core/system.py
@@ -1,7 +1,10 @@
 import os
 import shutil
+import sys
 
-from os.path import normpath, relpath, join, abspath
+from os.path import normpath, relpath, join
+
+from . import log
 
 build_dir = None
 intermediate_dir = None
@@ -11,13 +14,20 @@ temporary_dir = None
 def initialize(destination):
     global build_dir, intermediate_dir, temporary_dir
 
-    build_dir = abspath(destination)
+    build_dir = os.path.abspath(destination)
     cook = os.path.join(build_dir, '.cook/')
     intermediate_dir = os.path.join(cook, 'intermediate/')
     temporary_dir = os.path.join(cook, 'temporary/')
 
-    if not os.path.isdir(destination):
-        os.makedirs(destination)
+    if not os.path.isdir(build_dir):
+        os.makedirs(build_dir)
+    elif os.listdir(build_dir) and not os.path.isdir(cook):
+        log.error(
+            'The build directory "{}" is not empty and does not seem to be '
+            'the location of a previous build.'.format(build_dir)
+        )
+        sys.exit(1)
+
     if not os.path.isdir(cook):
         os.mkdir(cook)
     if not os.path.isdir(intermediate_dir):

--- a/cook/cpp.py
+++ b/cook/cpp.py
@@ -81,7 +81,7 @@ def executable(
             command.append('-Wl,-rpath,' + os.path.dirname(core.absolute(s)))
         command.append('-lstdc++')
         command.extend(linkflags)
-        core.call(command, env=os.environ)
+        core.call(command)
     elif toolchain is MSVC:
         command = [compiler, '/Fe' + name, '/nologo']
         command.extend(objects + shared + static)
@@ -229,7 +229,7 @@ def shared_library(
         command.extend(objects)
         command.append('-Wl,-soname,' + os.path.basename(name))
         command.extend(linkflags)
-        core.call(command, env=os.environ)
+        core.call(command)
     elif toolchain is MSVC:
         command = [compiler, '/Fe' + name, '/nologo', '/LD']
         command.extend(objects)
@@ -338,7 +338,7 @@ def object(
 
         command.extend(flags)
 
-        output = core.call(command, env=os.environ)
+        output = core.call(command)
 
         if scan:
             # TODO: Good parsing.
@@ -522,7 +522,7 @@ def _msvc_extract_vcvars(vcvars):
             '@echo LIB=%LIB%;%LIBPATH%'
         ]).format(vcvars=vcvars, mode='x86'))
     cmd = core.which('cmd.exe')
-    output = core.call([cmd, '/C', helper], env=os.environ)
+    output = core.call([cmd, '/C', helper])
     env = os.environ.copy()
     steps = 0
     for line in output.strip().splitlines():

--- a/cook/misc.py
+++ b/cook/misc.py
@@ -2,7 +2,10 @@ from cook import core
 
 
 @core.rule
-def run(command, outputs, inputs=None, message=None, env=None):
+def run(
+    command, outputs, inputs=None, message=None, env=None, timeout=None,
+    cwd=None
+):
     inputs = core.source(inputs or [])
     outputs = core.build(outputs)
     command[0] = core.which(command[0])
@@ -22,4 +25,4 @@ def run(command, outputs, inputs=None, message=None, env=None):
             real.extend(outputs)
         else:
             real.append(token)
-    core.call(real, env=env)
+    core.call(real, env=env, timeout=timeout, cwd=cwd)

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -81,7 +81,7 @@ Hello world!
 ## Next Steps
 
 If you are interested in creating custom rules, make sure to visit
-[the tutorial]({% link docs/getting-started.md %}). You can find more 
-information about the C++ rules [here]({% link docs/rules/cpp.md %}) or maybe
-take a look at the [features]({% link docs/features/index.md %}) provided by
-Cook and the [other rules]({% link docs/rules/index.md %})?
+[the tutorial]({% link docs/custom-rules.md %}). You can find more information
+about the C++ rules [here]({% link docs/rules/cpp.md %}) or maybe take a look
+at the [features]({% link docs/features/index.md %}) provided by Cook and the
+[other rules]({% link docs/rules/index.md %})?


### PR DESCRIPTION
This may fix issue #18. It adds three default environment variables: TEMP, TMP and PATH. 

Problem: Nonreproducability might be the result of adding PATH automatically to the calls. However, many programs do not function correctly without PATH.

Solutions:
- Require adding PATH manually each time.
- Automatically add PATH to each call (Reproducability must be investigated)
- Add PATH and invalidate rules when PATH changes
- Make all environment variables available by default (Reproducability must be investigated)
